### PR TITLE
Fix DNAVALIDATION portability

### DIFF
--- a/modules/local/dnavalidation/environment.yml
+++ b/modules/local/dnavalidation/environment.yml
@@ -5,3 +5,5 @@ channels:
   - bioconda
 dependencies:
   - conda-forge::bash=5.2.21
+  - conda-forge::grep=3.11
+  - conda-forge::gzip=1.13

--- a/modules/local/dnavalidation/meta.yml
+++ b/modules/local/dnavalidation/meta.yml
@@ -14,6 +14,12 @@ tools:
       documentation: "https://www.gnu.org/software/bash/manual/"
       licence: ["GPL-3.0-or-later"]
       version: "5.2.21"
+  - grep:
+      description: Search for patterns in text files
+      homepage: "https://www.gnu.org/software/grep/"
+      documentation: "https://www.gnu.org/software/grep/manual/"
+  - gzip:
+      description: GNU compression utilities used to uncompress the VCF
 
 input:
   - - meta:


### PR DESCRIPTION
## Summary
- add grep and gzip to DNAVALIDATION environment
- document grep and gzip usage in module metadata
- check variants using `gzip -cd` for better portability
- update DNAVALIDATION container images to match new tools

## Testing
- `nf-test modules/local/dnavalidation` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6856673c612c833188686c189316c2ae